### PR TITLE
feat(testing): expose ConfigFile in testing API

### DIFF
--- a/core/src/testing.rs
+++ b/core/src/testing.rs
@@ -14,4 +14,4 @@ pub mod process;
 mod regex;
 mod runner;
 
-pub use self::{regex::Regex, runner::CmdRunner};
+pub use self::{config::ConfigFile, regex::Regex, runner::CmdRunner};


### PR DESCRIPTION
For testing purposes, it would be useful, to have the `testing::config::ConfigFile` struct being exposed.

For example I can't use the internal `CmdRunner`, also because it doesn't support searching in command output ergonomically. So I use `assert_cmd`, but I like the ease of use of my config being serialized and injected in the call to the command runner, so I implemented:

```rust
pub trait AssertCmdExt {
    /// Add the given configuration file
    fn config(&mut self, config: &impl Serialize) -> &mut Self;
}
```

```rust
impl AssertCmdExt for Command {
    fn config(&mut self, config: &impl Serialize) -> &mut Self {
        let target_bin = self.get_program().to_owned();
        let config_file = ConfigFile::create(&target_bin, config);
        self.args(&["-c", &config_file.path().display().to_string()]);
        self
    }
}
```

```rust
/// Use configured value
#[rstest]
fn start_with_config_no_args(setup: Result<Command>) -> Result<()> {
    let mut config = RusticServerConfig::default();
    config.server.listen = SocketAddr::from(([127, 0, 0, 1], 8081));

    let assert = setup?.config(&config).arg("serve").arg("-v").assert();

    assert
        .stdout(predicates::str::contains("listen: 127.0.0.1:8081"))
        .success();

    Ok(())
}
```

So can we expose the ConfigFile in the public API for testing, please? 🙏🏽 